### PR TITLE
Fix missing shapely dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tifffile
 matplotlib
 scipy
 jupyter
+shapely


### PR DESCRIPTION
## Summary
- add shapely to requirements.txt to support ROI export

## Testing
- `python -m py_compile ThingDetector.py primary.py tools/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683f68040eec832384d2d20ff41083f6